### PR TITLE
Adding O_DIRECT flag via a env variable

### DIFF
--- a/src/H5FDgds.c
+++ b/src/H5FDgds.c
@@ -26,6 +26,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 
 #include <unistd.h>
 #include <sys/file.h>
@@ -245,6 +246,43 @@ static const H5FD_class_t H5FD_gds_g = {
     H5FD__gds_ctl,           /* ctl                  */
     H5FD_FLMAP_DICHOTOMY     /* fl_map               */
 };
+
+/*-------------------------------------------------------------------------
+ * Function:    H5FD__gds_parse_boolean_env
+ *
+ * Purpose:     Parse a boolean environment variable.
+ *              Accepts: "1", "true", "yes", "on" (case-insensitive) as TRUE
+ *                       "0", "false", "no", "off" (case-insensitive) as FALSE
+ *              If variable not set or empty, returns default_value.
+ *
+ * Return:      Boolean value
+ *
+ *-------------------------------------------------------------------------
+ */
+static hbool_t
+H5FD__gds_parse_boolean_env(const char *env_name, hbool_t default_value)
+{
+    const char *env_val = getenv(env_name);
+
+    if (!env_val || env_val[0] == '\0')
+        return default_value;
+
+    if (strcmp(env_val, "1") == 0 ||
+        strcasecmp(env_val, "true") == 0 ||
+        strcasecmp(env_val, "yes") == 0 ||
+        strcasecmp(env_val, "on") == 0)
+        return TRUE;
+
+    if (strcmp(env_val, "0") == 0 ||
+        strcasecmp(env_val, "false") == 0 ||
+        strcasecmp(env_val, "no") == 0 ||
+        strcasecmp(env_val, "off") == 0)
+        return FALSE;
+
+    fprintf(stderr, "Warning: Unrecognized value '%s' for %s, using default (%s)\n",
+            env_val, env_name, default_value ? "true" : "false");
+    return default_value;
+} /* end H5FD__gds_parse_boolean_env() */
 
 /*-------------------------------------------------------------------------
  * Function:    H5FD_gds_init
@@ -485,6 +523,15 @@ H5FD__gds_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr)
         o_flags |= O_CREAT;
     if (H5F_ACC_EXCL & flags)
         o_flags |= O_EXCL;
+
+    /* Check environment variable for O_DIRECT flag
+     * Accepts: 1, true, yes, on (case-insensitive) to enable
+     *          0, false, no, off (case-insensitive) to disable
+     * Default: enabled (TRUE) 
+     */
+    if (H5FD__gds_parse_boolean_env("HDF5_GDS_VFD_OPEN_DIRECT", TRUE)) {
+        o_flags |= O_DIRECT;
+    }
 
     /* Open the file */
     if ((fd = open(name, o_flags, H5FD_GDS_POSIX_CREATE_MODE_RW)) < 0)

--- a/src/H5FDgds.c
+++ b/src/H5FDgds.c
@@ -597,7 +597,6 @@ H5FD__gds_open(const char *name, unsigned flags, hid_t fapl_id, haddr_t maxaddr)
 
     /* Set return value */
     ret_value = (H5FD_t *)file;
-fprintf(stderr, "%s:%u - Successfully opened file w/GDS VFD\n", __func__, __LINE__);
 
 done:
     if (ret_value == NULL) {


### PR DESCRIPTION
The O_DIRECT flag is enabled by default and can be disabled via an env variable. This should help with cases where cuFile compat mode is used. At the moment, cuFile doesn't handle the O_DIRECT compatibility mode in all cases. If an unaligned read is issued, it goes back to buffered IO. If this is available in a future release of cuFile, it should work in all cases. 